### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 .idea
 .api_path
 .access_token
+composer.lock
+vendor/


### PR DESCRIPTION
adds composer.lock and vendor/ to .gitignore
this file and directory are generated by composer and not typically added to scm